### PR TITLE
Tracking state

### DIFF
--- a/run_config.yaml
+++ b/run_config.yaml
@@ -1,15 +1,17 @@
 dev:
     csv_file: ../data/url_lists/test_urls.csv
-    warc_folder: ../data/warcs/
-    db_folder: ../data/db/
+    warc_folder: ../data/dev/warcs/
+    db_folder: ../data/dev/db/
+    state_folder: ../data/dev/state/
     track_failed_urls: True
     new_failed_url_list: False
-    failed_url_list: ../data/url_lists/failed_URLs.txt
+    failed_url_list: ../data/dev/failed_URLs.txt
 
 prod:
     csv_file: ../data/url_lists/subdomain_list.txt
-    warc_folder: ../data/extracted/
-    db_folder: ../data/db/
+    warc_folder: ../data/prod/warcs/
+    db_folder: ../data/prod/db/
+    state_folder: ../data/prod/state/
     track_failed_urls: True
     new_failed_url_list: False
-    failed_url_list: ../data/url_lists/failed_URLs.txt
+    failed_url_list: ../data/prod/failed_URLs.txt

--- a/run_config.yaml
+++ b/run_config.yaml
@@ -1,13 +1,15 @@
 dev:
     csv_file: ../data/url_lists/test_urls.csv
-    output_base: ../public/
-    extraction_input_folder: ../data/warcs/
+    warc_folder: ../data/warcs/
     db_folder: ../data/db/
-    extraction_output_folder: ../data/extracted/
+    track_failed_urls: True
+    new_failed_url_list: False
+    failed_url_list: ../data/url_lists/failed_URLs.txt
 
 prod:
-    csv_file: ../data/url_lists/CDC_html_URLs_from_sitemap_data_-_20241201.csv
-    output_base: ../public/
-    extraction_input_folder: ../data/extracted/
+    csv_file: ../data/url_lists/subdomain_list.txt
+    warc_folder: ../data/extracted/
     db_folder: ../data/db/
-    extraction_output_folder: ../data/extracted_html/
+    track_failed_urls: True
+    new_failed_url_list: False
+    failed_url_list: ../data/url_lists/failed_URLs.txt

--- a/src/create_leveldb.py
+++ b/src/create_leveldb.py
@@ -1,8 +1,9 @@
-import plyvel
 import gzip
 import logging
 import os
 import re
+
+import plyvel
 from warcio.archiveiterator import ArchiveIterator
 
 def create_db(loc, dbfolder):

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -2,26 +2,28 @@
 
 import argparse
 import logging
-import os
+from pathlib import Path
+from sys import exit
+from time import time
+
+from clean_urlkey import detect_urlkeys_from_subdomains, read_urls_from_csv
 from config_loader import load_config
-from clean_urlkey import detect_urlkeys_from_subdomains
-from clean_urlkey import read_urls_from_csv
 from retrieve_snapshot import process_cdc_urls
 from create_leveldb import create_db
 
-# Checking and creating this folder separate from others, because we
-# start the logging config before anything else
-if not os.path.exists("../logs"):
-    print("Creating ../logs/")
-    os.mkdir("../logs", mode=0o755)
+# Logging directory setup
+LOG_DIR = Path("../logs")
+if not LOG_DIR.exists():
+    logging.info(f"Creating log directory: {LOG_DIR}")
+    LOG_DIR.mkdir(mode=0o755, parents=True)
 
 # Configure logging: logs to both console and a file
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s - %(levelname)s - %(funcName)s - %(message)s",
     handlers=[
-        logging.StreamHandler(),  # Log to console
-        logging.FileHandler("../logs/restoreCDCWarc.log")  # Log to file
+        logging.StreamHandler(),
+        logging.FileHandler(LOG_DIR / "restoreCDCWarc.log")
     ]
 )
 
@@ -33,36 +35,78 @@ def main():
         default="dev",
         help="Specify the run mode: 'dev' or 'prod'"
     )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+
+    # Then set log level dynamically:
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    logging.getLogger().setLevel(log_level)
 
     args = parser.parse_args()
-    # Load config
     config = load_config()
+    
+    required_keys = [
+        'csv_file', 'warc_folder', 'db_folder',
+        'track_failed_urls', 'new_failed_url_list', 'failed_url_list'
+    ]
+    for key in required_keys:
+        if key not in selected_config:
+            logging.error(f"Missing required config key: {key}")
+            exit(1)
 
-    # Select config based on run_mode
+    csv_path = Path(selected_config['csv_file'])
+    if not csv_path.exists():
+        logging.error(f"CSV file not found: {csv_path}")
+        exit(1)
+
+    if selected_config.get("track_failed_urls") and failed_urls:
+        with open(selected_config["failed_url_list"], "w") as f:
+            for url in failed_urls:
+                f.write(url + "\\n")
+        logging.info(f"Saved failed URLs to {selected_config['failed_url_list']}")
+
     if args.run_mode in config:
         selected_config = config[args.run_mode]
-        print(f"Running in {args.run_mode} mode with config: {selected_config}")
+        logging.info(f"Running in {args.run_mode} mode with config: {selected_config}")
     else:
-        print(f"Error: run_mode '{args.run_mode}' not found in config.yaml")
+        logging.error(f"run_mode '{args.run_mode}' not found in config.yaml")
+        exit(1)
 
     folders = [
-        selected_config['extraction_input_folder'],
-        selected_config['extraction_output_folder'], # Unused right now?
-        selected_config['db_folder'],
-        selected_config['output_base']
+        Path(selected_config['warc_folder']),
+        Path(selected_config['db_folder']),
+        Path(selected_config['output_base'])
     ]
     for folder in folders:
-        if os.path.exists(folder):
+        if folder.exists():
             continue
-        print(f"Creating {folder}")
-        os.makedirs(folder, mode=0o755)
+        logging.info(f"Creating directory: {folder}")
+        folder.mkdir(mode=0o755, parents=True)
+
+    start_time = time()
 
     subdomains = read_urls_from_csv(selected_config['csv_file'])
     url_list = detect_urlkeys_from_subdomains(subdomains)
-    process_cdc_urls(url_list, selected_config['extraction_input_folder'])
-    create_db(selected_config['extraction_input_folder'],
-              selected_config['db_folder'])
 
+    logging.debug("Starting process_cdc_urls")
+    process_cdc_urls(
+        url_list,
+        selected_config['warc_folder'],
+        selected_config['track_failed_urls'],
+        selected_config['failed_url_list']
+    )
+
+    logging.debug("Starting create_db")
+    create_db(
+        selected_config['warc_folder'],
+        selected_config['db_folder']
+    )
+    
+    duration = time() - start_time
+    logging.info(f"Script completed in {duration:.2f} seconds")
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        logging.exception(f"Unhandled exception: {e}")
+        exit(1)

--- a/src/retrieve_snapshot.py
+++ b/src/retrieve_snapshot.py
@@ -97,63 +97,6 @@ def get_warc_url(cdx_url):
     return warc_url
 
 
-def get_best_date_for_url(cdx_url):
-    """
-    Query the CDX API to get the closest WARC file URL before or on the target date.
-    :param cdx_url: URL to find archive for
-    :return none
-    """
-    # Format the CDX API URL for the query
-    # TODO A limit of 25,000 could make a tough bug to find; 
-    # if we run this in the future, and web.archive.org has made
-    # more than that many backups, we could end up not seeing the right version.
-    cdx_api_url = (
-        f"https://web.archive.org/cdx/search/cdx?"
-        f"url={cdx_url}"
-        f"&output=json"
-        f"&fl=timestamp,original,warc_url"
-        f"&limit=-1"
-        f"&to=20250119"
-    )
-    
-    # Send the request to the CDX API
-    response = get_with_retries(cdx_api_url)
-
-    if not response:
-        logging.error(
-            f"Failed to reach CDX API entirely."
-        )
-        return None
-
-    if response.status_code != 200:
-        logging.error(
-            f"Failed to query CDX API. HTTP status code: {response.status_code}"
-        )
-        return None
-
-    data = response.json()
-
-    # Filter snapshots that are on or before the target date
-    closest_snapshot = None
-    for entry in data[1:]:
-        timestamp = entry[0]
-        snapshot_date = datetime.strptime(timestamp, "%Y%m%d%H%M%S")
-        if snapshot_date <= TARGET_DATE:
-            closest_snapshot = entry
-        else:
-            break  # Since the data is sorted by date, no need to check further snapshots
-
-    if not closest_snapshot:
-        logging.error("No snapshots found before the target date.")
-        return None
-
-    # Extract the WARC URL and timestamp
-    url = closest_snapshot[1]
-    timestamp = closest_snapshot[0]
-    logging.info(f"Found closest snapshot: {url} for timestamp {timestamp}")
-    return timestamp
-
-
 def download_warc_cdx_toolkit(url, best_timestamp, warc_save_path):
     """
     Adapted from example: https://github.com/cocrawler/cdx_toolkit/blob/main/examples/iter-and-warc.py
@@ -180,31 +123,39 @@ def download_warc_cdx_toolkit(url, best_timestamp, warc_save_path):
 
     issues_seen = False
     match_found = False
-    #TODO Possible loss of data if it goes beyond this limit; ideally there's a method to check the size of cdx but there isn't always
-    for obj in cdx.iter(url, limit=10):
+
+    # TODO: Figure out how to call fetch_warc_record() directly
+    #       without the extra (redundant) /cdx/search/cdx ... API
+    #       call. It may involve fetching all the data
+    #       detect_urlkeys_from_subdomains() instead of just the url
+    #       and timestamp.
+    for obj in cdx.iter(url, limit=-20):
         timestamp = obj["timestamp"]
-        if timestamp == best_timestamp:
-            match_found = True
-            url = obj["url"]
-            status = obj["status"]
-            logging.info(
-                f"Considering extracting url: {url} with timestamp {timestamp}"
+        if timestamp != best_timestamp:
+            logging.debug(f"Skipping because {timestamp} != {best_timestamp}")
+            continue
+        match_found = True
+        url = obj["url"]
+        status = obj["status"]
+        logging.info(
+            f"Considering extracting url: {url} with timestamp {timestamp}"
+        )
+        if status != "200":
+            logging.debug("Skipping because status was {}, not 200".format(status))
+            issues_seen = True
+            continue
+        try:
+            record = obj.fetch_warc_record()
+        except RuntimeError:
+            logging.debug(
+                "Skipping capture for RuntimeError 404: %s %s", url, timestamp
             )
-            if status != "200":
-                logging.debug("Skipping because status was {}, not 200".format(status))
-                issues_seen = True
-                continue
-            try:
-                record = obj.fetch_warc_record()
-            except RuntimeError:
-                logging.debug(
-                    "Skipping capture for RuntimeError 404: %s %s", url, timestamp
-                )
-                issues_seen = True
-                continue
-            writer.write_record(record)
-            files.append(writer.filename)
-            logging.info(f"********SUCCESS!********** Wrote warc for {url}")
+            issues_seen = True
+            continue
+        writer.write_record(record)
+        files.append(writer.filename)
+        logging.info(f"********SUCCESS!********** Wrote warc for {url}")
+        break
     if not match_found:
         issues_seen = True
     return files, issues_seen
@@ -230,7 +181,8 @@ def process_cdc_urls(state_folder, base_dir, track_failed_urls, failed_urls, sub
                 fetched_fd.close()
         else:
             fetched_state = {}
-        for path in paths:
+        for url_data in paths:
+            (path, timestamp) = url_data
             url = os.path.join(subdomain + path)
             if path in fetched_state:
                 logging.info(f"Previous result for {path}: {fetched_state[path]}")
@@ -258,7 +210,6 @@ def process_cdc_urls(state_folder, base_dir, track_failed_urls, failed_urls, sub
                 logging.warning(f"Skipping processing for failed URL: {url}")
                 continue
                 
-            timestamp = get_best_date_for_url(url)
             files, issues = download_warc_cdx_toolkit(url, timestamp, warc_save_path)
             fetched_state[path] = { "files": files, "issues": issues }
             if issues:

--- a/src/retrieve_snapshot.py
+++ b/src/retrieve_snapshot.py
@@ -197,12 +197,13 @@ def download_warc_cdx_toolkit(url, best_timestamp, warc_save_path):
             logging.info(f"********SUCCESS!********** Wrote warc for {url}")
 
 
-def process_cdc_urls(subdomains, base_dir):
+def process_cdc_urls(subdomains, base_dir, failed_urls):
     """
     Process a list of URLs, download the closest WARC snapshot, and extract resources.
     :param subdomains: a nested list of subdomains and paths to use to find WARC archives
     :param base_dir: a file location to save the WARC
-    :return none
+    :param failed_urls: a file where failed URLs are logged
+    :return: none
     """
 
     for subdomain, paths in subdomains.items():


### PR DESCRIPTION
- Reorganized data/ folders so there are now dev/ and prod/ sub-folders
- Added a state_folder configuration entry, and ensure it exists
- Changed clean_urls() to return a list instead of a set, which is how we're using it anyway, and it can be sorted
- Track the list of URLs in <state-dir>/url_list.<subdomain>.list
- Track the previous results of warc retrieve attempts in <state-dir>/fetched.<subdomain>.json
- Write the (previous, or current run) failed URLs in failed_URLs.txt
- Experimentally use limit=-1 and to=20250119 filters in get_warc_url() and get_best_date_for_url(), which should return just one most recent match with the date-restriction given
- download_warc_cdx_toolkit() now return a list of warc files (if any
      were written) and a flag (boolean) to give a clue whether there were
      problems. This has a lot of room for improvement, but is a start.
- process_cdc_urls() checks against, and writes to the fetched.*.json
      files, to avoid fetching the same data repeatedly while debugging.
- Sorting the list of URLs, so we'll hopefully get the higher level
      pages earlier on in the process. No difference in the long run but
      may help while developing/debugging.