### PR TITLE
WARC download streamlining, first serve.py tweaks

### DIFF
--- a/data/url_lists/test_urls.csv
+++ b/data/url_lists/test_urls.csv
@@ -1,2 +1,1 @@
-nccd.cdc.gov
 hivrisk.cdc.gov

--- a/src/clean_urlkey.py
+++ b/src/clean_urlkey.py
@@ -120,7 +120,7 @@ def detect_urlkeys_from_subdomains(state_folder, subdomains):
         url = f"{netloc}/"
 
         cdx_call = (
-            f"http://web.archive.org/cdx/search/cdx?"
+            f"https://web.archive.org/cdx/search/cdx?"
             f"url={url}"
             f"&matchType=prefix"
             f"&from=20200101"
@@ -133,9 +133,13 @@ def detect_urlkeys_from_subdomains(state_folder, subdomains):
             response = requests.get(cdx_call)
             if response.status_code == 200:
                 raw_data = json.loads(response.text)
-                raw_headers = raw_data[0]
-                raw_data = raw_data[1:]
-                cleaned_data = clean_urls(raw_headers, raw_data)
+                if len(raw_data) == 0:
+                    logging.error(f"No data found at all for {netloc}!")
+                    cleaned_data = []
+                else:
+                    raw_headers = raw_data[0]
+                    raw_data = raw_data[1:]
+                    cleaned_data = clean_urls(raw_headers, raw_data)
                 urlkeys[netloc] = cleaned_data
 
                 # Preserve the list in the appropriate state_file

--- a/src/clean_urlkey.py
+++ b/src/clean_urlkey.py
@@ -32,16 +32,28 @@ def read_urls_from_csv(file_path):
         logging.critical(f"Error reading CSV file {file_path}: {e}")
     return urls
 
-def clean_urls(url_list):
+def clean_urls(url_headers, url_list):
     """
     Remove archival prefix (e.g., timestamps or metadata) before the close parenthesis ')'.
     
     :param url_list: A list of lists of URLs and timestamps
     :return: A list of cleaned URL paths.
     """
+    headers = {}
+    for ix, header in enumerate(url_headers):
+        headers[header] = ix
+
+    url_headers.append("path")
+    headers['path'] = len(url_headers) - 1
+
+    url_headers.append('originals')
+    headers['originals'] = len(url_headers) - 1
+
     url_timestamps = {}
+    url_collection = {}
     for url_data in url_list:
-        (raw_path, timestamp) = url_data
+        raw_path = url_data[headers["urlkey"]]
+        timestamp = url_data[headers["timestamp"]]
         try:
             if isinstance(raw_path, bytes):
                 raw_path = raw_path.decode("utf-8")
@@ -54,19 +66,29 @@ def clean_urls(url_list):
                 print(f"raw_path = {raw_path}")
                 path = raw_path
 
-            if path not in url_timestamps:
+            url_data.append(path)
+            original = url_data[headers['original']]
+            if not (path in url_timestamps):
+                # First time seeing this urlkey-path
+                url_data.append([ original ])
                 url_timestamps[path] = timestamp
-                continue
-            if timestamp > url_timestamps[path]:
+                url_collection[path] = url_data
+            elif timestamp > url_timestamps[path]:
+                originals = url_collection[path][headers['originals']]
+                logging.debug(f"Repeat of {path} - {original} vs {originals}")
+                if not (original in originals):
+                    originals.append(original)
+                url_data.append(originals)
                 url_timestamps[path] = timestamp
+                url_collection[path] = url_data
         except (ValueError, UnicodeDecodeError) as e:
             logging.warning(f"Skipping malformed URL entry: {raw_path} — {e}")
         except Exception as e:
             logging.critical(f"Unexpected error cleaning URL {raw_path}: {e}")
     
     cleaned_paths = []
-    for path, timestamp in url_timestamps.items():
-        cleaned_paths.append([ path, timestamp ])
+    for path, url_data in url_collection.items():
+        cleaned_paths.append(dict(zip(url_headers, url_collection[path])))
     return cleaned_paths
 
 def detect_urlkeys_from_subdomains(state_folder, subdomains):
@@ -89,7 +111,7 @@ def detect_urlkeys_from_subdomains(state_folder, subdomains):
                 cleaned_data = []
                 for line in state_fd:
                     line = line.rstrip()
-                    cleaned_data.append(line.split(" "))
+                    cleaned_data.append(json.loads(line))
                 urlkeys[netloc] = cleaned_data
                 state_fd.close()
             logging.info(f"Retrieved {len(urlkeys[netloc])} URLs for {netloc} from state file.")
@@ -104,7 +126,6 @@ def detect_urlkeys_from_subdomains(state_folder, subdomains):
             f"&from=20200101"
             f"&to=20250119"
             f"&filter=statuscode:200"
-            f"&fl=urlkey,timestamp"
             f"&output=json"
         )
 
@@ -112,14 +133,15 @@ def detect_urlkeys_from_subdomains(state_folder, subdomains):
             response = requests.get(cdx_call)
             if response.status_code == 200:
                 raw_data = json.loads(response.text)
+                raw_headers = raw_data[0]
                 raw_data = raw_data[1:]
-                cleaned_data = clean_urls(raw_data)
+                cleaned_data = clean_urls(raw_headers, raw_data)
                 urlkeys[netloc] = cleaned_data
 
                 # Preserve the list in the appropriate state_file
                 with open(state_file, 'w', encoding='utf-8') as state_fd:
                     for url in cleaned_data:
-                        state_fd.write(f"{url[0]} {url[1]}\n")
+                        state_fd.write(json.dumps(url) + "\n")
                     state_fd.close()
             else:
                 logging.error(f"Error retrieving urlkeys for subdomain: {netloc} — Status code: {response.status_code}")

--- a/src/clean_urlkey.py
+++ b/src/clean_urlkey.py
@@ -75,7 +75,6 @@ def clean_urls(url_headers, url_list):
                 url_collection[path] = url_data
             elif timestamp > url_timestamps[path]:
                 originals = url_collection[path][headers['originals']]
-                logging.debug(f"Repeat of {path} - {original} vs {originals}")
                 if not (original in originals):
                     originals.append(original)
                 url_data.append(originals)

--- a/src/create_leveldb.py
+++ b/src/create_leveldb.py
@@ -6,44 +6,63 @@ import re
 import plyvel
 from warcio.archiveiterator import ArchiveIterator
 
-def create_db(loc, dbfolder):
+def create_db(url_list_plus, dbfolder):
     """
     In a given location unpack gzipped files and extract URL and contents into LevelDB
-    :param loc: local directory with read and write permissions
+    :param url_list_plus: Hashmap with information about the URLs found at the IA and where they were saved locally
+    :param dbfolder: target directory for the LevelDB
     """
-    directory = os.fsencode(loc)
     db = plyvel.DB(os.path.join(dbfolder, 'cdc_database'), create_if_missing=True)
 
     content_db = db.prefixed_db(b"c-")
     mimetype_db = db.prefixed_db(b"m-")
-    
-    for file in os.listdir(directory):
-        filename = os.fsdecode(file)
-        full_path = os.path.join(loc, filename)
 
-        logging.debug(f"Opening file{full_path}")
-        file_contents = None
-        
-        if filename.endswith(".gz"):
-            stream = gzip.open(full_path, 'rb')
-        elif filename.endswith(".warc"):
-            stream = open(full_path, 'rb')
-        else:
-            continue
+    total_path = 0
+    total_url = 0
+    for subdomain, paths in url_list_plus.items():
+        for url_data in paths:
+            total_path += 1
+            for filename in url_data['fetched']['files']:
+                logging.debug(f"Opening file{filename}")
+                file_contents = None
 
-        for record in ArchiveIterator(stream):
-            if record.rec_type == 'response':
-                uri = record.rec_headers.get_header('WARC-Target-URI')
-                payload = record.content_stream().read()
-                if uri and payload:
-                    content_type = record.http_headers.get_header('Content-Type')
-                    content_db.put(uri.encode('utf-8'), payload)
-                    
-                    if content_type:
-                        mimetype_db.put(uri.encode('utf-8'), content_type.encode('utf-8'))
-                        
-                    logging.info(f"Saved record: {uri} [{content_type}]")
+                if filename.endswith(".gz"):
+                    stream = gzip.open(filename, 'rb')
+                elif filename.endswith(".warc"):
+                    stream = open(filename, 'rb')
+                else:
+                    continue
 
-        stream.close()
-            
-    db.close()       
+                for record in ArchiveIterator(stream, no_record_parse=False, ensure_http_headers=True):
+                    if record.rec_type != 'response':
+                        if record.rec_type != "warcinfo":
+                            logging.debug(f"Record type '{record.rec_type}' skipped.")
+                        continue
+                    uri = record.rec_headers.get_header('WARC-Target-URI')
+                    payload = record.content_stream().read()
+                    logging.debug(f"uri = {uri}")
+                    if uri and payload is not None:
+                        if not record.http_headers:
+                            logging.info("No http_headers for this warc record")
+                            continue
+
+                        urls = url_data['originals']
+                        if not (uri in urls):
+                            urls.append(uri)
+                        # logging.debug(f"urls: {urls}; uri: {uri}; path: {url_data['path']}; originals: {url_data['originals']}")
+
+                        content_type = record.http_headers.get_header('Content-Type')
+                        for url in urls:
+                            content_db.put(url.encode('utf-8'), payload)
+
+                            if content_type:
+                                mimetype_db.put(url.encode('utf-8'), content_type.encode('utf-8'))
+                            total_url += 1
+                        logging.info(f"Saved record: {uri} [{content_type}]")
+                    else:
+                        logging.debug(f"Payload: {payload}")
+                stream.close()
+
+    db.close()
+
+    logging.info(f"Inserted {total_path} paths into the LevelDB, for {total_url} URL variations")

--- a/src/create_leveldb.py
+++ b/src/create_leveldb.py
@@ -22,46 +22,49 @@ def create_db(url_list_plus, dbfolder):
     for subdomain, paths in url_list_plus.items():
         for url_data in paths:
             total_path += 1
-            for filename in url_data['fetched']['files']:
-                logging.debug(f"Opening file{filename}")
-                file_contents = None
+            filename = url_data['fetched']['file']
+            if not filename:
+                logging.debug(f"Missing warc file for {url_data}")
+                continue
+            logging.debug(f"Opening file{filename}")
+            file_contents = None
 
-                if filename.endswith(".gz"):
-                    stream = gzip.open(filename, 'rb')
-                elif filename.endswith(".warc"):
-                    stream = open(filename, 'rb')
-                else:
+            if filename.endswith(".gz"):
+                stream = gzip.open(filename, 'rb')
+            elif filename.endswith(".warc"):
+                stream = open(filename, 'rb')
+            else:
+                continue
+
+            for record in ArchiveIterator(stream, no_record_parse=False, ensure_http_headers=True):
+                if record.rec_type != 'response':
+                    if record.rec_type != "warcinfo":
+                        logging.debug(f"Record type '{record.rec_type}' skipped.")
                     continue
-
-                for record in ArchiveIterator(stream, no_record_parse=False, ensure_http_headers=True):
-                    if record.rec_type != 'response':
-                        if record.rec_type != "warcinfo":
-                            logging.debug(f"Record type '{record.rec_type}' skipped.")
+                uri = record.rec_headers.get_header('WARC-Target-URI')
+                payload = record.content_stream().read()
+                logging.debug(f"uri = {uri}")
+                if uri and payload is not None:
+                    if not record.http_headers:
+                        logging.info("No http_headers for this warc record")
                         continue
-                    uri = record.rec_headers.get_header('WARC-Target-URI')
-                    payload = record.content_stream().read()
-                    logging.debug(f"uri = {uri}")
-                    if uri and payload is not None:
-                        if not record.http_headers:
-                            logging.info("No http_headers for this warc record")
-                            continue
 
-                        urls = url_data['originals']
-                        if not (uri in urls):
-                            urls.append(uri)
-                        # logging.debug(f"urls: {urls}; uri: {uri}; path: {url_data['path']}; originals: {url_data['originals']}")
+                    urls = url_data['originals']
+                    if not (uri in urls):
+                        urls.append(uri)
+                    # logging.debug(f"urls: {urls}; uri: {uri}; path: {url_data['path']}; originals: {url_data['originals']}")
 
-                        content_type = record.http_headers.get_header('Content-Type')
-                        for url in urls:
-                            content_db.put(url.encode('utf-8'), payload)
+                    content_type = record.http_headers.get_header('Content-Type')
+                    for url in urls:
+                        content_db.put(url.encode('utf-8'), payload)
 
-                            if content_type:
-                                mimetype_db.put(url.encode('utf-8'), content_type.encode('utf-8'))
-                            total_url += 1
-                        logging.info(f"Saved record: {uri} [{content_type}]")
-                    else:
-                        logging.debug(f"Payload: {payload}")
-                stream.close()
+                        if content_type:
+                            mimetype_db.put(url.encode('utf-8'), content_type.encode('utf-8'))
+                        total_url += 1
+                    logging.info(f"Saved record: {uri} [{content_type}]")
+                else:
+                    logging.debug(f"Payload: {payload}")
+            stream.close()
 
     db.close()
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -82,7 +82,7 @@ def main():
     url_list = detect_urlkeys_from_subdomains(selected_config['state_folder'], subdomains)
 
     logging.debug("Starting process_cdc_urls")
-    failed_urls = process_cdc_urls(
+    failed_urls, url_list_plus = process_cdc_urls(
         selected_config['state_folder'],
         selected_config['warc_folder'],
         selected_config['track_failed_urls'],
@@ -98,7 +98,7 @@ def main():
 
     logging.debug("Starting create_db")
     create_db(
-        selected_config['warc_folder'],
+        url_list_plus,
         selected_config['db_folder']
     )
     

--- a/src/retrieve_snapshot.py
+++ b/src/retrieve_snapshot.py
@@ -17,11 +17,11 @@ def download_warc_cdx_toolkit(subdomain, url_data, warc_save_path):
     :param url: a URL to find WARC
     :param best_timestamp: a datetime used to find WARC
     :param warc_save_path: a path where the WARC will be saved
-    :return: A list of *.warc(.gz) files, and a flag indicating if we noticed any problems
+    :return: the .warc(.gz) file name, and a flag indicating if we noticed any problems
     """
     url = url_data['original']
     timestamp = url_data['timestamp']
-    files = []
+    warc_file = None
     logging.debug(f"Attempting to download warc for {url}")
     cdx = cdx_toolkit.CDXFetcher(source="ia")
     warcinfo = {
@@ -56,9 +56,9 @@ def download_warc_cdx_toolkit(subdomain, url_data, warc_save_path):
         return [], True
 
     writer.write_record(record)
-    files.append(writer.filename)
-    logging.info(f"********SUCCESS!********** Wrote warc for {url} at {writer.filename}")
-    return files, False
+    warc_file = writer.filename
+    logging.info(f"********SUCCESS!********** Wrote warc for {url} at {warc_file}")
+    return warc_file, False
 
 def process_cdc_urls(state_folder, base_dir, track_failed_urls, failed_urls, subdomains):
     """
@@ -108,8 +108,8 @@ def process_cdc_urls(state_folder, base_dir, track_failed_urls, failed_urls, sub
                                                         # filename length errors
                                                         # doesnt affect actual URL
 
-            files, issues = download_warc_cdx_toolkit(subdomain, url_data, warc_save_path)
-            fetched_state[path] = { "files": files, "issues": issues }
+            warc_file, issues = download_warc_cdx_toolkit(subdomain, url_data, warc_save_path)
+            fetched_state[path] = { "file": warc_file, "issues": issues }
             if issues:
                 failed_urls.append(url)
 

--- a/src/retrieve_snapshot.py
+++ b/src/retrieve_snapshot.py
@@ -1,103 +1,17 @@
 # Standard library imports
-import csv
+import copy
 import json
 import logging
 import os
-import time
-from datetime import datetime
 
 # Third-party imports
-import requests
 import cdx_toolkit
 
-# Local application/library imports
-from constants import TARGET_DATE
-
-def get_with_retries(url, max_retries=5, delay=3, failed_urls=None, track_failures=True):
-    """
-    Handling requests with retries and timeouts
-    :param url: URL to try
-    :param max_retries: integer for maximum number of retries to attempt
-    :param delay: time in seconds for delay calculations
-    :param failed_urls: optional list to collect URLs that fail all attempts
-    :param track_failures: if True, append failed URL to list
-    :return: Response object or None
-    """
-    for attempt in range(max_retries):
-        try:
-            return requests.get(url, timeout=30)
-        except requests.exceptions.ReadTimeout as e:
-            logging.error(f"Attempt {attempt+1} timed out for URL {url}: {e}")
-            time.sleep(delay * (2 ** attempt))
-            continue
-        except requests.exceptions.ConnectionError as e:
-            logging.error(f"Attempt {attempt+1} connection failed for URL {url}: {e}")
-            time.sleep(delay * (2 ** attempt))
-            continue
-        except Exception as e:
-            logging.error(f"Unexpected error for URL {url} on attempt {attempt+1}: {e}")
-            continue
-    logging.warning(f"Skipping URL after {max_retries} failed attempts: {url}")
-    if failed_urls is not None and track_failures:
-        failed_urls.append(url)
-    return None
-
-
-def get_warc_url(cdx_url):
-    """
-    Query the CDX API to get the closest WARC file URL before or on the target date.
-    :param cdx_url: URL used to find archive for
-    :return none
-    """
-    # Format the CDX API URL for the query
-    cdx_api_url = (
-        f"https://web.archive.org/cdx/search/cdx?"
-        f"url={cdx_url}"
-        f"&output=json"
-        f"&fl=timestamp,original,warc_url"
-        f"&limit=-1"
-        f"&to=20250119"
-    )
-    # Send the request to the CDX API
-    response = get_with_retries(cdx_api_url)
-
-    if not response:
-        logging.error(
-            f"Failed to reach CDX API entirely."
-        )
-        return None
-
-    if response.status_code != 200:
-        logging.error(
-            f"Failed to query CDX API. HTTP status code: {response.status_code}"
-        )
-        return None
-
-    data = response.json()
-
-    # Filter snapshots that are on or before the target date
-    closest_snapshot = None
-    for entry in data[1:]:
-        timestamp = entry[0]
-        snapshot_date = datetime.strptime(timestamp, "%Y%m%d%H%M%S")
-        if snapshot_date <= TARGET_DATE:
-            closest_snapshot = entry
-        else:
-            break  # Since the data is sorted by date, no need to check further snapshots
-
-    if not closest_snapshot:
-        logging.error("No snapshots found before the target date.")
-        return None
-    # Extract the WARC URL and timestamp
-    warc_url = closest_snapshot[1]
-    timestamp = closest_snapshot[0]
-    logging.info(
-        f"Found closest snapshot: {warc_url} for timestamp {timestamp}"
-    )
-    return warc_url
-
-
-def download_warc_cdx_toolkit(url, best_timestamp, warc_save_path):
+# The one thing slowing this down right now is the retry_info settings
+# in cdx_toolkit/myrequests.py which prescribe a minimum interval of 6
+# seconds between requests. A sensible interval, but it means several
+# subdomains are going to take quite some time to collect.
+def download_warc_cdx_toolkit(subdomain, url_data, warc_save_path):
     """
     Adapted from example: https://github.com/cocrawler/cdx_toolkit/blob/main/examples/iter-and-warc.py
     :param url: a URL to find WARC
@@ -105,6 +19,8 @@ def download_warc_cdx_toolkit(url, best_timestamp, warc_save_path):
     :param warc_save_path: a path where the WARC will be saved
     :return: A list of *.warc(.gz) files, and a flag indicating if we noticed any problems
     """
+    url = url_data['original']
+    timestamp = url_data['timestamp']
     files = []
     logging.debug(f"Attempting to download warc for {url}")
     cdx = cdx_toolkit.CDXFetcher(source="ia")
@@ -116,49 +32,33 @@ def download_warc_cdx_toolkit(url, best_timestamp, warc_save_path):
     }
 
     #logging.debug(f"$warc_save_path: {warc_save_path}")
-    
+
     writer = cdx_toolkit.warc.get_writer(
         warc_save_path, "", warcinfo
     )
 
-    issues_seen = False
-    match_found = False
+    # Copying the 'wb' value that cdx_toolkit.CDXFetcher.__init__()
+    # sets for source="ia":
+    data = copy.deepcopy(url_data)
+    data['url'] = f"https://{subdomain}{data['path']}"
+    # del data['path']
+    # del data['original']
+    data['status'] = data['statuscode']
+    # del data['statuscode']
+    data['mime'] = data['mimetype']
+    # del data['statuscode']
+    obj = cdx_toolkit.CaptureObject(data, wb='https://web.archive.org/web')
 
-    # TODO: Figure out how to call fetch_warc_record() directly
-    #       without the extra (redundant) /cdx/search/cdx ... API
-    #       call. It may involve fetching all the data
-    #       detect_urlkeys_from_subdomains() instead of just the url
-    #       and timestamp.
-    for obj in cdx.iter(url, limit=-20):
-        timestamp = obj["timestamp"]
-        if timestamp != best_timestamp:
-            logging.debug(f"Skipping because {timestamp} != {best_timestamp}")
-            continue
-        match_found = True
-        url = obj["url"]
-        status = obj["status"]
-        logging.info(
-            f"Considering extracting url: {url} with timestamp {timestamp}"
-        )
-        if status != "200":
-            logging.debug("Skipping because status was {}, not 200".format(status))
-            issues_seen = True
-            continue
-        try:
-            record = obj.fetch_warc_record()
-        except RuntimeError:
-            logging.debug(
-                "Skipping capture for RuntimeError 404: %s %s", url, timestamp
-            )
-            issues_seen = True
-            continue
-        writer.write_record(record)
-        files.append(writer.filename)
-        logging.info(f"********SUCCESS!********** Wrote warc for {url}")
-        break
-    if not match_found:
-        issues_seen = True
-    return files, issues_seen
+    try:
+        record = obj.fetch_warc_record()
+    except RuntimeError:
+        logging.debug("Skipping capture for RuntimeError 404: %s %s", url, timestamp)
+        return [], True
+
+    writer.write_record(record)
+    files.append(writer.filename)
+    logging.info(f"********SUCCESS!********** Wrote warc for {url} at {writer.filename}")
+    return files, False
 
 def process_cdc_urls(state_folder, base_dir, track_failed_urls, failed_urls, subdomains):
     """
@@ -168,12 +68,15 @@ def process_cdc_urls(state_folder, base_dir, track_failed_urls, failed_urls, sub
     :param track_failed_urls: flag to indicate how to handle failed URLs
     :param failed_urls: a file where failed URLs are logged
     :param subdomains: a nested list of subdomains and paths to use to find WARC archives
-    :return: a list of failed URLs
+    :return: a list of failed URLs, plus an extended version of the subdomains structure
     """
 
     failed_urls = []
 
+    url_list_plus = {}
+
     for subdomain, paths in subdomains.items():
+        url_list_plus[subdomain] = []
         fetched_file = f"{state_folder}/fetched.{subdomain}.json"
         if os.path.exists(fetched_file):
             with open(fetched_file, "r", encoding="utf-8") as fetched_fd:
@@ -182,44 +85,39 @@ def process_cdc_urls(state_folder, base_dir, track_failed_urls, failed_urls, sub
         else:
             fetched_state = {}
         for url_data in paths:
-            (path, timestamp) = url_data
+            path = url_data['path']
+            timestamp = url_data['timestamp']
             url = os.path.join(subdomain + path)  
             if path in fetched_state:
                 logging.info(f"Previous result for {path}: {fetched_state[path]}")
                 if fetched_state[path]['issues']:
                     failed_urls.append(url)
+                url_data = copy.deepcopy(url_data)
+                url_data['fetched'] = fetched_state[path]
+                url_list_plus[subdomain].append(url_data)
                 continue
-            logging.info(f"========== Processing URL: {url} ==========")
+
+            logging.info(f"========== Processing URL: {url} [{timestamp}] ==========")
 
             # Define the prefix for saving the WARC segments
             warc_filename = (
                 url.replace("/", "_") 
             )
-            
+
             warc_save_path = os.path.join(base_dir, warc_filename)[:150]# need to truncate to avoid 
                                                         # filename length errors
                                                         # doesnt affect actual URL
-            
-            #logging.debug(f"$warc_save_path: {warc_save_path}")
-            #logging.debug(f"$warc_filename: {warc_filename}")
 
-            #check if warc already exists
-            if os.path.exists(warc_save_path):
-                logging.debug(f"warc exists: {warc_save_path}")
-                continue
-                
-            if url in failed_urls:
-                logging.warning(f"Skipping processing for failed URL: {url}")
-                continue
-                
-            files, issues = download_warc_cdx_toolkit(url, timestamp, warc_save_path)
+            files, issues = download_warc_cdx_toolkit(subdomain, url_data, warc_save_path)
             fetched_state[path] = { "files": files, "issues": issues }
             if issues:
                 failed_urls.append(url)
 
+            url_data = copy.deepcopy(url_data)
+            url_data['fetched'] = fetched_state[path]
             # Write intermediate state to disk, so we can pick it up
             # if we abort the process or it crashes
             with open(fetched_file, "w", encoding="utf-8") as fetched_fd:
                 json.dump(fetched_state, fetched_fd)
                 fetched_fd.close()
-    return failed_urls
+    return failed_urls, url_list_plus

--- a/src/serve.py
+++ b/src/serve.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import json
 import logging
@@ -46,9 +48,92 @@ app = Flask(__name__)
 hostName = args.hostname
 serverPort = args.port
 
+def rewrite_html_urls(full_path, content):
+    """
+    Rewrite any of these to point to ourselves, as needed
+
+    <a      href="...">
+    <link   href="...">
+    <script src="...">
+    <img    src="...">
+
+    :param full_path: The full path, to find the relevant (sub)domain
+    :param content: The HTML content as bytes
+    :return: Rewritten (if needed) HTML content as bytes
+
+    The proper way will be to parse the HTML, and then cross our
+    fingers there is nothing in the HTML comments to parse, but for
+    now the initial version this does a broad set of text replaces.
+
+    There are also places with references to the original websites in
+    srcset attributes and such, so there are no doubt other hidden
+    treasures.
+    """
+    path_match = re.match(r"https://([^/]+)/", full_path)
+    if not path_match:
+        # Can't do anything useful here
+        return content
+    website = path_match.group(1)
+
+    # Looks like the hivrisk.cdc.gov site had some stray references to their staging site,
+    # not that it makes much of a difference :)
+    content = content.replace(b"hivriskstage.cdc.gov", b"hivrisk.cdc.gov")
+
+    content = content.replace(bytes(f" https://{website}/", "utf-8"),
+                              bytes(f" /https://{website}/", "utf-8"))
+    content = content.replace(b"href=\"/", bytes(f"href=\"/https://{website}/", "utf-8"))
+    content = content.replace(bytes(f"href=\"https://{website}/", "utf-8"),
+                              bytes(f"href=\"/https://{website}/", "utf-8"))
+    content = content.replace(bytes(f"href=\'https://{website}/", "utf-8"),
+                              bytes(f"href=\'/https://{website}/", "utf-8"))
+    content = content.replace(bytes(f"src=\"https://{website}/", "utf-8"),
+                              bytes(f"src=\"/https://{website}/", "utf-8"))
+    content = content.replace(bytes(f"src=\'https://{website}/", "utf-8"),
+                              bytes(f"src=\'/https://{website}/", "utf-8"))
+
+    return content
+
+def find_content(full_path):
+    """
+    Find the relevant content, possibly adding or removing an extra '/'
+
+    :param full_path: The original URL, as bytes
+    :return: Two values, the content (as bytes), ans the mimetype (as str)
+    """
+    raw_key = bytes(full_path, "utf-8")
+
+    logging.debug(f"Looking up key: {full_path}")
+    content = content_db.get(raw_key)
+    mimetype_bytes = mimetype_db.get(raw_key)
+
+    if content is None or mimetype_bytes is None:
+        # Try with, or without a / at the end
+        key_match = re.match(r"([^?]+)/\?(.*)$", full_path)
+        if key_match:
+            raw_key = bytes(key_match.group(1) + "?" + key_match.group(2), "utf-8")
+        else:
+            key_match = re.match(r"([^?]+)\?(.*)$", full_path)
+            if key_match:
+                raw_key = bytes(key_match.group(1) + "/?" + key_match.group(2), "utf-8")
+            else:
+                raw_key = raw_key + b"/"
+        logging.debug(f"Looking up secondary key: {raw_key}")
+        content = content_db.get(raw_key)
+        mimetype_bytes = mimetype_db.get(raw_key)
+        if content is None or mimetype_bytes is None:
+            logging.warning(f"Missing content or mimetype for path: {full_path}")
+            return None, None
+
+        logging.debug(f"Found {raw_key} after modification")
+
+    mimetype = mimetype_bytes.decode("utf-8")
+
+    return content, mimetype
+
 @app.route("/")
 def home():
     """
+    Default route
     """
     return redirect("/www.cdc.gov/")
 
@@ -58,30 +143,34 @@ def lookup(subpath):
     Catch-all route
     """
     try:
-        full_path = parse.unquote(subpath)
+        if request.query_string:
+            full_path = request.full_path[1:]
+        else:
+            full_path = request.path[1:]
         logging.debug(f"Full path: {full_path}")
         # Fix missing slash if needed
         if full_path.startswith("https:/") and not full_path.startswith("https://"):
             full_path = full_path.replace("https:/", "https://", 1)
-        logging.debug(f"Full path fixed: {full_path}")            
-            
+            logging.debug(f"Full path fixed: {full_path}")
+
+        content, mimetype = find_content(full_path)
         raw_key = bytes(full_path, "UTF-8")
 
-        logging.debug(f"Looking up key: {raw_key}")
-
-        content = content_db.get(raw_key)
-        mimetype_bytes = mimetype_db.get(raw_key)
-
-        if content is None or mimetype_bytes is None:
-            logging.warning(f"Missing content or mimetype for path: {full_path}")
+        if content is None or mimetype is None:
             return Response("Not Found", status=404)
-
-        mimetype = mimetype_bytes.decode("utf-8")
 
         if mimetype == "=redirect=":
             redirect_target = content.decode("utf-8")
             logging.info(f"Redirecting from {full_path} to {redirect_target}")
             return redirect(f'/{redirect_target}')
+
+        logging.debug(f"Mime type {mimetype} for {full_path}")
+
+        if full_path.startswith("https://") and mimetype == "text/html" or mimetype.startswith("text/html;"):
+            content = rewrite_html_urls(full_path, content)
+
+        # XXX: We probably also need to rewrite URLs in javascript and
+        #      stylesheets that we serve up
 
         return Response(content, mimetype=mimetype)
 


### PR DESCRIPTION
- Removed nccd.cdc.gov at test URL, focus on hivrisk.cdc.gov for now
- clean_urlkey.py:
  - detect_urlkeys_from_subdomains() gets all fields, uses HTTPS for the fetch
  - clean_urls() keeps the most recent timestamp for each urlkey, but also collects the multiple original (full URLs), as there are a few duplicates
 - retrieve_snapshot.py:
   - Using the timestamps that were tracked (in clean_urls, detect_urlkeys_from_subdomains), we can jump straight to a WARC download, and avoid extra API calls (if there is a better way than how I did that in download_warc_cdx_toolkit(), I'm all ears)
   - process_cdc_urls() takes the structured data and adds the "fetched" section to it, with the "file" and "issues" entries, so we know exactly which warc belongs to what urlkey and the original URLs
 - pipeline.py is mostly a case of juggling the new structures around
 
- serve.py has been extended to do a minimal (and a bit of a hack, without HTML parsing) amount of text substitutions so that the pages retried from IA can find the relevant javascript, stylesheets, images, and more links point back to us where possible
